### PR TITLE
Fix download issues

### DIFF
--- a/Model/Sync.php
+++ b/Model/Sync.php
@@ -101,6 +101,10 @@ class Sync
      */
     protected function saveFileFromRemoteServer($src, $target)
     {
+        if (strstr($target, 'media/') !== false) {
+            $src = preg_replace('/^media\//', '', $src);
+        }
+
         $fileSaved = false;
         $fileName = basename($src);
         $fileDirectory = $target;

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "magento/module-media-storage": "*"
     },
     "type": "magento2-module",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "license": "MIT",
     "autoload": {
         "files": [

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,5 +18,12 @@
                 <download_limit>50</download_limit>
             </general>
         </phoenix_mediastoragesync>
+        <system>
+            <media_storage_configuration>
+                <allowed_resources>
+                    <media_folder>media</media_folder>
+                </allowed_resources>
+            </media_storage_configuration>
+        </system>
     </default>
 </config>


### PR DESCRIPTION
First issue targeted is the fact, that the download via `pub/get.php` was skipped, as the `media` folder is not listed as allowed resource.
This is fixed by adding it as allowed to the `media_storage_configuration`.

Second issue was the problem, that the `media` folder was present in the source path as well as in the target path.
![src_target](https://user-images.githubusercontent.com/1203434/92461052-09998d00-f1c9-11ea-884e-e9e943cb9ebf.png)
Addressed this issue with checking if `media/` is already contained in target path and strip it from the source if necessary.